### PR TITLE
Use the galaxy_file option to install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,6 @@ The following software must be installed/present on your local machine before yo
   - [VMware Fusion](http://www.vmware.com/products/fusion/) (or Workstation - if you want to build the VMware box)
   - [Ansible](http://docs.ansible.com/intro_installation.html)
 
-You will also need some Ansible roles installed so they can be used in the building of the VM. To install the roles:
-
-  1. Run `$ ansible-galaxy install -r requirements.txt` in this directory.
-  2. If your local Ansible roles path is not the default (`/etc/ansible/roles`), update the `role_paths` inside `ubuntu1604.json` to match your custom location.
-
-If you don't have Ansible installed (perhaps you're using a Windows PC?), you can simply clone the required Ansible roles from GitHub directly (use [Ansible Galaxy](https://galaxy.ansible.com/) to get the GitHub repository URLs for each role listed in `requirements.txt`), and update the `role_paths` variable to match the location of the cloned role.
-
 ## Usage
 
 Make sure all the required software (listed above) is installed, then cd to the directory containing this README.md file, and run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-geerlingguy.packer-debian
-geerlingguy.nfs

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: geerlingguy.packer-debian
+- src: geerlingguy.nfs

--- a/ubuntu1604.json
+++ b/ubuntu1604.json
@@ -13,10 +13,7 @@
     {
       "type": "ansible-local",
       "playbook_file": "ansible/main.yml",
-      "role_paths": [
-        "/etc/ansible/roles/geerlingguy.packer-debian",
-        "/etc/ansible/roles/geerlingguy.nfs"
-      ]
+      "galaxy_file": "requirements.yml"
     },
     {
       "type": "shell",


### PR DESCRIPTION
Packer introduced the galaxy_file option in 0.11.0 to install roles from galaxy inside the box. This makes it much more easier to use external roles, because you don't need to know the path of the roles on your system.  

I also renamed the requirements file to the yaml standard. 

See: https://github.com/mitchellh/packer/pull/3350