### PR TITLE
updated to latest bionic iso image

### DIFF
--- a/ubuntu1804/box-config.json
+++ b/ubuntu1804/box-config.json
@@ -61,7 +61,7 @@
         "ubuntu-18.04.6-server-amd64.iso",
         "http://cdimage.ubuntu.com/ubuntu/releases/bionic/release/ubuntu-18.04.6-server-amd64.iso"
       ],
-      "iso_checksum": "sha256:8c5fc24894394035402f66f3824beb7234b757dd2b5531379cb310cedfdf0996",
+      "iso_checksum": "sha256:f5cbb8104348f0097a8e513b10173a07dbc6684595e331cb06f93f385d0aecf6",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_port": 22,


### PR DESCRIPTION
The 18.04.5 iso for amd64 has been removed from [canonicals release server](https://cdimage.ubuntu.com/ubuntu/releases/bionic/release/). I updated the iso path download path to the latest bionic release 18.04.6. I confirmed that the ISO for 18.04.6 is available.