### PR TITLE
Update boot_command

### DIFF
--- a/rockylinux8/box-config.json
+++ b/rockylinux8/box-config.json
@@ -23,7 +23,7 @@
     {
       "type": "virtualbox-iso",
       "boot_command": [
-        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
+        "<tab> text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
       ],
       "boot_wait": "10s",
       "disk_size": 81920,


### PR DESCRIPTION
Warning from Anaconda:
  dracut-cmdline[nnn]: Warning: ks has been deprecated.  All usage of Anaconda boot arguments without 'inst.' prefix have been deprecated and will be removed in a future major release.  Please use inst.ks instead.

Fixed #98 