### PR TITLE
Update rockylinux8 to 8.10

### DIFF
--- a/rockylinux8/box-config.json
+++ b/rockylinux8/box-config.json
@@ -31,10 +31,10 @@
       "headless": true,
       "http_directory": "http",
       "iso_urls": [
-        "Rocky-8.5-x86_64-dvd1.iso",
-        "https://download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.5-x86_64-dvd1.iso"
+        "Rocky-8.10-x86_64-dvd1.iso",
+        "https://download.rockylinux.org/pub/rocky/8/isos/x86_64/Rocky-8.10-x86_64-dvd1.iso"
       ],
-      "iso_checksum": "sha256:0081f8b969d0cef426530f6d618b962c7a01e71eb12a40581a83241f22dfdc25",
+      "iso_checksum": "sha256:642ada8a49dbeca8cca6543b31196019ee3d649a0163b5db0e646c7409364eeb",
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_port": 22,


### PR DESCRIPTION
Rocky Linux 8.5 repos are no longer supported breaking box building.